### PR TITLE
also swap Int64 literals on 32-bits systems

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 The `SafeREPL` package allows to swap, in the REPL, the meaning of Julia's
 literals (in particular numbers).
 Upon loading, the default is to replace `Float64` literals with `BigFloat`,
-and `Int` and `Int128` literals with `BigInt`.
+and `Int`, `Int64` and `Int128` literals with `BigInt`.
 A literal prefixed with `$` is left unchanged.
 
 ```julia
@@ -45,6 +45,8 @@ The four arguments of this function correspond to
 Passing `nothing` means not transforming literals of this type, and
 a symbol is interpreted as the name of a function to be applied to the value.
 The last argument defaults to `nothing`.
+On 32-bits systems, `Int64` literals are transformed in the same way as `Int`
+literals.
 
 A single boolean value can also be passed: `swapliterals!(false)` deactivates
 `SafeREPL` and `swapliterals!(true)` re-activates it with the previous setting.

--- a/SwapLiterals/src/SwapLiterals.jl
+++ b/SwapLiterals/src/SwapLiterals.jl
@@ -14,9 +14,16 @@ makedict(@nospecialize(pairs)) =
 
 makedict(@nospecialize(pairs::AbstractDict)) = pairs
 
-const defaultswaps = makedict(Any[Float64 => "@big_str",
-                                  Int     => :big,
-                                  Int128  => :big])
+const defaultswaps =
+    let swaps = Any[Float64 => "@big_str",
+                    Int     => :big,
+                    Int128  => :big]
+
+        if Int === Int32
+            push!(swaps, Int64 => :big)
+        end
+        makedict(swaps)
+    end
 
 """
     floats_use_rationalize!(yesno::Bool=true)
@@ -208,6 +215,10 @@ macro swapliterals(swaps...)
             swaps = Any[Float64=>swaps[1], Int=>swaps[2], Int128=>swaps[3], BigInt=>swaps[4]]
         else
             throw(ArgumentError("wrong number of arguments"))
+        end
+        if Int !== Int64
+            # transform Int64 in the same way we transform Int == Int32
+            push!(swaps, Int64 => last(swaps[2]))
         end
     end
 

--- a/SwapLiterals/test/runtests.jl
+++ b/SwapLiterals/test/runtests.jl
@@ -25,10 +25,12 @@ makecoloneq(ex) = Expr(:(=),
     @swapliterals :BigFloat :big "@big_str" begin
         @test 1 == Int(1)
         @test 1 isa BigInt
+        @test 10000000000 isa BigInt # Int64 literals are transformed like Int literals
         @test 1.2 isa BigFloat
         @test 1.2 == big"1.1999999999999999555910790149937383830547332763671875"
         @test 1.0 == Float64(1.0)
         @test $1 isa Int
+        @test $10000000000 isa Int64 # even on 32-bits systems
         @test $1.2 isa Float64
     end
 
@@ -37,6 +39,7 @@ makecoloneq(ex) = Expr(:(=),
         @test 1.2 isa BigFloat
         @test 1.2 == big"1.2"
         @test 1 isa BigInt
+        @test 10000000000 isa BigInt # Int64 literals are transformed like Int literals
         @test 11111111111111111111 isa BigInt
     end
     @swapliterals "@big_str" :big :big begin
@@ -49,7 +52,21 @@ makecoloneq(ex) = Expr(:(=),
         @test 1.2 isa BigFloat
         @test 1.2 == big"1.2"
         @test 1 isa BigInt
+        if Int === Int64
+            @test 10000000000 isa BigInt
+        else
+            @test 10000000000 isa Int64 # Int64 literals are *not* transformed like Int literals
+        end
         @test 11111111111111111111 isa BigInt
+    end
+
+    @swapliterals Int64 => :big begin
+        if Int === Int64
+            @test 1 isa BigInt
+        else
+            @test 1 isa Int
+        end
+        @test 10000000000 isa BigInt
     end
 
     # TODO: these tests in loop are dubious
@@ -96,6 +113,10 @@ makecoloneq(ex) = Expr(:(=),
     @swapliterals :Float64 :Int128 "@int128_str" begin
         x = 1
         @test x == Int(1) && x isa Int128
+        x = 10000000000
+        @test x == big"10000000000"
+        @test x isa Int128 # Int64 literals are transformed like Int literals
+
         x = 11111111111111111111
         @test x == Int128(11111111111111111111) && x isa Int128
         x = 1111111111111111111111111111111111111111
@@ -113,6 +134,8 @@ makecoloneq(ex) = Expr(:(=),
     @swapliterals nothing nothing nothing begin
         x = 1.0
         @test x isa Float64
+        @test 1 isa Int
+        @test 10000000000 isa Int64
         x = 11111111111111111111
         @test x isa Int128
         x = 1111111111111111111111111111111111111111

--- a/src/SafeREPL.jl
+++ b/src/SafeREPL.jl
@@ -34,6 +34,10 @@ end
 Specify transformations for literals:
 argument `Float64` corresponds to literals of type `Float64`, etcetera.
 
+!!! note
+    On 32-bits systems, the transformation for `Int` is also applied on
+    `Int64` literals.
+
 A transformation can be
 * a `Symbol`, to refer to a function, e.g. `:big`;
 * `nothing` to not transform literals of this type;
@@ -46,7 +50,11 @@ function swapliterals!(Float64,
                        Int128,
                        BigInt=nothing)
     @nospecialize
-    swapliterals!(; Float64, Int, Int128, BigInt)
+    if Base.Int === Base.Int64
+        swapliterals!(; Float64, Int, Int128, BigInt)
+    else
+        swapliterals!(; Float64, Int, Int64=Int, Int128, BigInt)
+    end
 end
 
 function swapliterals!(@nospecialize(swaps::AbstractDict))


### PR DESCRIPTION
Cf. https://discourse.julialang.org/t/whats-the-accepted-way-to-ensure-same-integer-behavior-between-32-bit-and-64-bit-julia/49564.