### PR TITLE
do not fail with non-Function transforms

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name    = "SafeREPL"
 uuid    = "5e6a0ad9-8e90-40fa-86b1-deb43b8cfda7"
 authors = ["Rafael Fourquet <fourquet.rafael@gmail.com>"]
-version = "0.1.1"
+version = "0.1.2"
 
 [deps]
 REPL         = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
@@ -15,4 +15,4 @@ test = ["Pkg"]
 
 [compat]
 julia = "1.5"
-SwapLiterals = "0.1.1"
+SwapLiterals = "0.1.2"

--- a/src/SafeREPL.jl
+++ b/src/SafeREPL.jl
@@ -81,14 +81,17 @@ end
 function swapliterals!(activate::Bool)
     transforms = get_transforms()
     # first always de-activate
-    filter!(f -> parentmodule(f) != SwapLiterals, transforms)
+    filter!(!is_swapliterals_transform, transforms)
     if activate
         push!(transforms, LAST_SWAPPER[])
     end
     nothing
 end
 
-isactive() = any(==(SwapLiterals) ∘ parentmodule, get_transforms())
+isactive() = any(is_swapliterals_transform, get_transforms())
+
+# typeof is necessary in cases where ff is a "functor" (a callable non-`Function`)
+is_swapliterals_transform(ff) = parentmodule(typeof(ff)) == SwapLiterals
 
 
 end # module


### PR DESCRIPTION
When ast transforms contained a callable non-Function, calling `parentmodule` on it would fail, so first call typeof on it. Affected functions were `isactive` and `swapliterals!(::Bool)`.